### PR TITLE
added optimized text rendering for icons

### DIFF
--- a/styles/_html.css
+++ b/styles/_html.css
@@ -171,6 +171,10 @@ h2 .favicon, h2.favicon, h2 a.favicon:link, h2 a.favicon:visited {
 	padding: 4px 4px;
 }
 .material-icons {
+
+  /*Support for Webkit based Browsers*/
+  text-rendering: optimizeLegibility;
+
 	margin-right: 2px;
 	vertical-align: middle;
 }


### PR DESCRIPTION
Right now, mdl icons do not show up when using Blink based browsers not called Chrome. This small change ensures that users of those browsers will have icons when they user reader self. 

Here is an image of what reader self looks like in vivaldi browser without the change implemented.
![screenshot 2015-08-21 20 12 59](https://cloud.githubusercontent.com/assets/2111879/9421836/40b2a952-4841-11e5-89dc-c757dce2b2a4.png)

Here's reader self after the change.
![screenshot 2015-08-21 20 16 39](https://cloud.githubusercontent.com/assets/2111879/9421846/8d2408bc-4841-11e5-8de2-e2a9d748c7ab.png)

