### PR TITLE
LDAP improvement

### DIFF
--- a/application/controllers/Password.php
+++ b/application/controllers/Password.php
@@ -8,6 +8,9 @@ class Password extends CI_Controller {
 		if($this->readerself_model->count_members() == 0) {
 			redirect(base_url().'register');
 		}
+		if(!$this->config->item('password_reset')) {
+			redirect(base_url());
+		}
 		if($this->axipi_session->userdata('mbr_id')) {
 			redirect(base_url().'home');
 		}

--- a/application/controllers/Profile.php
+++ b/application/controllers/Profile.php
@@ -11,13 +11,13 @@ class Profile extends CI_Controller {
 
 		$this->load->library(array('form_validation'));
 
-		if(!$this->config->item('ldap')) {
+		if(!$this->member->mbr_auth_ldap) {
 			$this->form_validation->set_rules('mbr_email', 'lang:mbr_email', 'required|valid_email|max_length[255]|callback_email');
 			$this->form_validation->set_rules('mbr_email_confirm', 'lang:mbr_email_confirm', 'required|valid_email|max_length[255]|matches[mbr_email]');
 			$this->form_validation->set_rules('mbr_password', 'lang:mbr_password');
 			$this->form_validation->set_rules('mbr_password_confirm', 'lang:mbr_password_confirm', 'matches[mbr_password]');
+			$this->form_validation->set_rules('mbr_nickname', 'lang:mbr_nickname', 'alpha_dash|max_length[255]|callback_nickname');
 		}
-		$this->form_validation->set_rules('mbr_nickname', 'lang:mbr_nickname', 'alpha_dash|max_length[255]|callback_nickname');
 		if($this->config->item('gravatar')) {
 			$this->form_validation->set_rules('mbr_gravatar', 'lang:gravatar', 'valid_email|max_length[255]');
 		}
@@ -29,13 +29,13 @@ class Profile extends CI_Controller {
 			$content = $this->load->view('profile_index', $data, TRUE);
 			$this->readerself_library->set_content($content);
 		} else {
-			if(!$this->config->item('ldap')) {
+			if(!$this->member->mbr_auth_ldap) {
 				$this->db->set('mbr_email', $this->input->post('mbr_email'));
 				if($this->input->post('mbr_password') != '' && $this->input->post('mbr_password_confirm') != '') {
 					$this->db->set('mbr_password', $this->readerself_library->set_salt_password($this->input->post('mbr_password')));
 				}
+				$this->db->set('mbr_nickname', $this->input->post('mbr_nickname'));
 			}
-			$this->db->set('mbr_nickname', $this->input->post('mbr_nickname'));
 			if($this->config->item('gravatar')) {
 				$this->db->set('mbr_gravatar', $this->input->post('mbr_gravatar'));
 			}

--- a/application/controllers/Register.php
+++ b/application/controllers/Register.php
@@ -8,7 +8,7 @@ class Register extends CI_Controller {
 		if($this->readerself_model->count_members() > 0 && !$this->config->item('register_multi')) {
 			redirect(base_url());
 		}
-		if($this->config->item('register_multi') && $this->config->item('ldap')) {
+		if($this->config->item('register_multi') && !$this->config->item('register')) {
 			redirect(base_url());
 		}
 		if($this->axipi_session->userdata('mbr_id')) {

--- a/application/database/installation-mysql.sql
+++ b/application/database/installation-mysql.sql
@@ -144,6 +144,7 @@ CREATE TABLE IF NOT EXISTS `members` (
   `mbr_email` varchar(255) NOT NULL,
   `mbr_password` char(40) NOT NULL,
   `mbr_nickname` varchar(255) DEFAULT NULL,
+  `mbr_auth_ldap` tinyint(1) NOT NULL DEFAULT '0',
   `mbr_gravatar` varchar(255) DEFAULT NULL,
   `mbr_description` text,
   `mbr_administrator` tinyint(1) unsigned NOT NULL DEFAULT '0',

--- a/application/database/installation-sqlite.sql
+++ b/application/database/installation-sqlite.sql
@@ -120,6 +120,7 @@ CREATE TABLE IF NOT EXISTS `members` (
   `mbr_email` varchar(255) NOT NULL,
   `mbr_password` char(40) NOT NULL,
   `mbr_nickname` varchar(255) DEFAULT NULL,
+  `mbr_auth_ldap` tinyint(1) NOT NULL DEFAULT '0',
   `mbr_gravatar` varchar(255) DEFAULT NULL,
   `mbr_description` text,
   `mbr_administrator` INTEGER NOT NULL DEFAULT '0',

--- a/application/database/update-mysql-3.5.4.sql
+++ b/application/database/update-mysql-3.5.4.sql
@@ -1,0 +1,1 @@
+ALTER TABLE members ADD mbr_auth_ldap TINYINT(1) NOT NULL DEFAULT '0';

--- a/application/database/update-sqlite-3.5.4.sql
+++ b/application/database/update-sqlite-3.5.4.sql
@@ -1,0 +1,1 @@
+ALTER TABLE members ADD COLUMN mbr_auth_ldap TINYINT(1) NOT NULL DEFAULT '0';

--- a/application/views/_html.php
+++ b/application/views/_html.php
@@ -133,14 +133,16 @@
 					<?php if($this->router->class != 'login') { ?>
 						<a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" href="<?php echo base_url(); ?>login"><i class="material-icons md-24">power_settings_new</i></a>
 					<?php } ?>
-					<?php if($this->config->item('register_multi') && !$this->config->item('ldap')) { ?>
+					<?php if($this->config->item('register_multi') && $this->config->item('register')) { ?>
 						<a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" href="<?php echo base_url(); ?>register"><i class="material-icons md-24">person_add</i></a>
 					<?php } ?>
 					<button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" id="hdrbtn">
 						<i class="material-icons md-24">more_vert</i>
 					</button>
 					<ul class="mdl-menu mdl-js-menu mdl-js-ripple-effect mdl-menu--bottom-right mdl-color--<?php echo $this->config->item('material-design/colors/background/menu'); ?>" for="hdrbtn">
+						<?php if($this->config->item('password_reset')) { ?>
 						<li class="mdl-menu__item"><a class="mdl-color-text--<?php echo $this->config->item('material-design/colors/text/link'); ?>" href="<?php echo base_url(); ?>password"><?php echo $this->lang->line('password'); ?></a>
+						<?php } ?>
 						<li class="mdl-menu__item"><a target="_blank" class="mdl-color-text--<?php echo $this->config->item('material-design/colors/text/link'); ?>" href="https://github.com/readerself">Code</a></li>
 						<li class="mdl-menu__item"><a target="_blank" class="mdl-color-text--<?php echo $this->config->item('material-design/colors/text/link'); ?>" href="https://www.facebook.com/readerself">Community</a></li>
 					</ul>

--- a/application/views/profile_index.php
+++ b/application/views/profile_index.php
@@ -31,31 +31,29 @@
 
 				<?php echo form_open(current_url()); ?>
 
-				<?php if(!$this->config->item('ldap')) { ?>
-					<p>
-					<?php echo form_label($this->lang->line('mbr_email'), 'mbr_email'); ?>
-					<?php echo form_input('mbr_email', set_value('mbr_email', $this->member->mbr_email), 'id="mbr_email" class="valid_email required"'); ?>
-					</p>
+				<p>
+				<?php echo form_label($this->lang->line('mbr_email'), 'mbr_email'); ?>
+				<?php echo form_input('mbr_email', set_value('mbr_email', $this->member->mbr_email), 'id="mbr_email" class="valid_email required"'.($this->member->mbr_auth_ldap ? ' disabled="disabled"' : '')); ?>
+				</p>
 
-					<p>
-					<?php echo form_label($this->lang->line('mbr_email_confirm'), 'mbr_email_confirm'); ?>
-					<?php echo form_input('mbr_email_confirm', set_value('mbr_email_confirm', $this->member->mbr_email), 'id="mbr_email_confirm" class="valid_email required"'); ?>
-					</p>
+				<p>
+				<?php echo form_label($this->lang->line('mbr_email_confirm'), 'mbr_email_confirm'); ?>
+				<?php echo form_input('mbr_email_confirm', set_value('mbr_email_confirm', $this->member->mbr_email), 'id="mbr_email_confirm" class="valid_email required"'.($this->member->mbr_auth_ldap ? ' disabled="disabled"' : '')); ?>
+				</p>
 
-					<p>
-					<?php echo form_label($this->lang->line('mbr_password'), 'mbr_password'); ?>
-					<?php echo form_password('mbr_password', set_value('mbr_password'), 'id="mbr_password"'); ?>
-					</p>
+				<p>
+				<?php echo form_label($this->lang->line('mbr_password'), 'mbr_password'); ?>
+				<?php echo form_password('mbr_password', set_value('mbr_password'), 'id="mbr_password"'.($this->member->mbr_auth_ldap ? ' disabled="disabled"' : '')); ?>
+				</p>
 
-					<p>
-					<?php echo form_label($this->lang->line('mbr_password_confirm'), 'mbr_password_confirm'); ?>
-					<?php echo form_password('mbr_password_confirm', set_value('mbr_password_confirm'), 'id="mbr_password_confirm"'); ?>
-					</p>
-				<?php } ?>
+				<p>
+				<?php echo form_label($this->lang->line('mbr_password_confirm'), 'mbr_password_confirm'); ?>
+				<?php echo form_password('mbr_password_confirm', set_value('mbr_password_confirm'), 'id="mbr_password_confirm"'.($this->member->mbr_auth_ldap ? ' disabled="disabled"' : '')); ?>
+				</p>
 
 				<p>
 				<?php echo form_label($this->lang->line('mbr_nickname'), 'mbr_nickname'); ?>
-				<?php echo form_input('mbr_nickname', set_value('mbr_nickname', $this->member->mbr_nickname), 'id="mbr_nickname"'); ?>
+				<?php echo form_input('mbr_nickname', set_value('mbr_nickname', $this->member->mbr_nickname), 'id="mbr_nickname"'.($this->member->mbr_auth_ldap ? ' disabled="disabled"' : '')); ?>
 				</p>
 
 				<?php if($this->config->item('gravatar')) { ?>

--- a/application/views/setup_config.php
+++ b/application/views/setup_config.php
@@ -1,14 +1,18 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 $config['salt_password'] = '<?php echo $salt_password; ?>';
-$config['ldap'] = '';
+$config['register'] = true;
+$config['password_reset'] = true;
+$config['ldap'] = false;
 $config['ldap_server'] = 'ldap://localhost';
 $config['ldap_port'] = 389;
 $config['ldap_protocol'] = 3;
 $config['ldap_rootdn'] = 'cn=Manager,dc=my-domain,dc=com';
 $config['ldap_rootpw'] = 'secret';
 $config['ldap_basedn'] = 'dc=my-domain,dc=com';
-$config['ldap_filter'] = 'mail=[email]';
+$config['ldap_login_filter'] = '(|(uid=%login)(mail=%login))';
+$config['ldap_user_email'] = 'mail';
+$config['ldap_user_nickname'] = 'uid';
 $config['email_protocol'] = 'mail';
 $config['smtp_host'] = '';
 $config['smtp_user'] = '';


### PR DESCRIPTION
## Details

- add a property to members table to flag ldap members and prevent them to login if ldap has been disabled
- update login methode :
  - if ldap is enabled, try to find user in ldap, if not found try to found it in db
  - email and nickname are supported in ldap login
  - setting member nickname and email from a specified ldap property set in the config file
- add specific config to enable/disable reset password and register actions (no more link with ldap config)
- disable nickname input in profile form for ldap users 
- show inputs on profile form as disabled instead of hiding them

I think that would be great to add web configuration access and a check to verify that the ldap user still exist in each request.
I'll try to do that when i'll get more time.